### PR TITLE
Add float to builtin scalar types tuple

### DIFF
--- a/ariadne_graphql_modules/dependencies.py
+++ b/ariadne_graphql_modules/dependencies.py
@@ -17,7 +17,7 @@ from graphql import (
 
 from .utils import unwrap_type_node
 
-GRAPHQL_TYPES = ("ID", "Int", "String", "Boolean")
+GRAPHQL_TYPES = ("ID", "Int", "String", "Boolean", "Float")
 
 Dependencies = Tuple[str, ...]
 

--- a/tests/test_object_type.py
+++ b/tests/test_object_type.py
@@ -83,6 +83,7 @@ def test_object_type_extracts_graphql_name():
 
 
 def test_object_type_accepts_all_builtin_scalar_types():
+    # pylint: disable=unused-variable
     class FancyObjectType(ObjectType):
         __schema__ = """
         type FancyObject {

--- a/tests/test_object_type.py
+++ b/tests/test_object_type.py
@@ -82,6 +82,19 @@ def test_object_type_extracts_graphql_name():
     assert GroupType.graphql_name == "Group"
 
 
+def test_object_type_accepts_all_builtin_scalar_types():
+    class FancyObjectType(ObjectType):
+        __schema__ = """
+        type FancyObject {
+            id: ID!
+            someInt: Int!
+            someFloat: Float!
+            someBoolean: Boolean!
+            someString: String!
+        }
+        """
+
+
 def test_object_type_raises_error_when_defined_without_return_type_dependency(snapshot):
     with pytest.raises(ValueError) as err:
         # pylint: disable=unused-variable


### PR DESCRIPTION
## What
Adds missing `Float` to built-in scalar types (`GRAPHQL_TYPES` in `ariadne_graphql_modules/dependencies.py` tuple)

## Tests
Added check to `test_object_type_accepts_all_builtin_scalar_types`

Fixes #1 