### PR TITLE
Simplify old API compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## 0.7.0 (UNRELEASED)
+## 0.7.0 (2022-09-13)
 
 - Added support for Ariadne schema definitions to `make_executable_schema`.
 

--- a/MOVING.md
+++ b/MOVING.md
@@ -8,9 +8,6 @@ Moving guide
 
 To be able to mix old and new approaches in your implementation, replace `make_executable_schema` imported from `ariadne` with one from `ariadne_graphql_modules`:
 
-- Move String (or strings) with your schema SDL from first argument to `extra_sdl` option.
-- Gather Bindables in a list and move them to `extra_bindables` option. 
-
 Old code:
 
 ```python
@@ -30,10 +27,23 @@ from ariadne_graphql_modules import make_executable_schema
 type_defs = load_schema_from_path("schema.graphql")
 
 schema = make_executable_schema(
-    extra_sdl=type_defs,
-    extra_bindables=[type_a, type_b, type_c],
+    type_defs, type_a, type_b, type_c,
 )
 ```
+
+If you are passing `type_defs` or types as lists (behavior supported by `ariadne.make_executable_schema`), you'll need to unpack them before passing:
+
+```python
+from ariadne import load_schema_from_path
+from ariadne_graphql_modules import make_executable_schema
+
+type_defs = load_schema_from_path("schema.graphql")
+
+schema = make_executable_schema(
+    type_defs, type_a, *user_types,
+)
+```
+
 
 If you are using directives, `directives` option is named `extra_directives` in new function:
 
@@ -44,8 +54,7 @@ from ariadne_graphql_modules import make_executable_schema
 type_defs = load_schema_from_path("schema.graphql")
 
 schema = make_executable_schema(
-    extra_sdl=type_defs,
-    extra_bindables=[type_a, type_b, type_c],
+    type_defs, type_a, type_b, type_c,
     extra_directives={"date": MyDateDirective},
 )
 ```
@@ -113,7 +122,7 @@ class UserType(ObjectType):
 
 
 schema = make_executable_schema(
-    UserType, extra_sdl=type_defs, extra_bindables=[query_type]
+    UserType, type_defs, query_type
 )
 ```
 
@@ -156,7 +165,7 @@ class NewQueryType(ObjectType):
 
 
 schema = make_executable_schema(
-    NewQueryType, extra_sdl=type_defs, extra_bindables=[query_type]
+    NewQueryType, type_defs, query_type
 )
 ```
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -757,7 +757,7 @@ Extends `DefinitionType`.
 
 ```python
 def make_executable_schema(
-    *types: BaseType,
+    *args: Union[Type[BaseType], SchemaBindable, str],
     merge_roots: bool = True,
     extra_sdl: Optional[Union[str, Sequence[str]]] = None,
     extra_bindables: Optional[Sequence[SchemaBindable]] = None,
@@ -766,7 +766,7 @@ def make_executable_schema(
     ...
 ```
 
-Utility function that takes args with types and creates executable schema.
+Utility function that takes args with types definitions and creates executable schema.
 
 
 ### `merge_roots: bool = True`
@@ -813,27 +813,9 @@ type Query {
 When `merge_roots=False` is explicitly set, `make_executable_schema` will raise an GraphQL error that `type Query` is defined more than once.
 
 
-### `extra_sdl`
-
-String or list of strings containing extra SDL to append in created schema. Optional.
-
-Used when moving schema definition to Ariadne GraphQL Modules approach from existing schema definition.
-
-See [moving guide](./MOVING.md) for examples and details.
-
-
-### `extra_bindables`
-
-List of Ariadne's bindables. Optional.
-
-Used when moving schema definition to Ariadne GraphQL Modules approach from existing schema definition.
-
-See [moving guide](./MOVING.md) for examples and details.
-
-
 ### `extra_directives`
 
-Dict of Ariadne's directives names and implementation. Optional
+Dict of Ariadne's directives names and implementation. Optional.
 
 Used when moving schema definition to Ariadne GraphQL Modules approach from existing schema definition.
 

--- a/ariadne_graphql_modules/executable_schema.py
+++ b/ariadne_graphql_modules/executable_schema.py
@@ -1,7 +1,5 @@
 from typing import (
-    Any,
     Dict,
-    Iterable,
     List,
     Optional,
     Sequence,

--- a/tests/test_executable_schema_compat.py
+++ b/tests/test_executable_schema_compat.py
@@ -37,9 +37,7 @@ def test_old_schema_definition_is_executable():
     def resolve_user_score(user, _):
         return user["id"] * 7
 
-    schema = make_executable_schema(
-        extra_sdl=type_defs, extra_bindables=[query_type, user_type]
-    )
+    schema = make_executable_schema(type_defs, query_type, user_type)
 
     _, result = graphql_sync(schema, {"query": "{ random user { id name score } }"})
     assert result == {
@@ -92,9 +90,7 @@ def test_old_schema_depending_on_new_types_is_executable():
         def resolve_score(user, _):
             return user["id"] * 7
 
-    schema = make_executable_schema(
-        UserType, extra_sdl=type_defs, extra_bindables=[query_type]
-    )
+    schema = make_executable_schema(UserType, type_defs, query_type)
 
     _, result = graphql_sync(schema, {"query": "{ random user { id name score } }"})
     assert result == {
@@ -148,9 +144,7 @@ def test_new_schema_depending_on_old_types_is_executable():
     def resolve_user_score(user, _):
         return user["id"] * 7
 
-    schema = make_executable_schema(
-        QueryType, extra_sdl=type_defs, extra_bindables=[user_type]
-    )
+    schema = make_executable_schema(QueryType, type_defs, user_type)
 
     _, result = graphql_sync(schema, {"query": "{ random user { id name score } }"})
     assert result == {
@@ -212,9 +206,7 @@ def test_old_and_new_roots_can_be_combined():
                 "name": "Alice",
             }
 
-    schema = make_executable_schema(
-        NewQueryType, extra_sdl=type_defs, extra_bindables=[query_type]
-    )
+    schema = make_executable_schema(NewQueryType, type_defs, query_type)
 
     _, result = graphql_sync(schema, {"query": "{ random user { id name score } }"})
     assert result == {


### PR DESCRIPTION
This PR adds bit of magic to `make_executable_schema` so it becomes a more or less drop-in replacement for old one, making it even easier to make a switch.

Old code:

```python
from ariadne import make_executable_schema

schema = make_executable_schema(type_defs, query_type, user_type)
```

New code:

```python
from ariadne_graphql_modules import make_executable_schema

schema = make_executable_schema(type_defs, query_type, user_type)
```